### PR TITLE
added bash and curl to the image. Had to fix docker-compose in the pr…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
-FROM docker:latest
+FROM docker:stable
 LABEL maintainer "Nithiwat Kampanya"
 
-RUN apk --no-cache add groff less python py-pip jq python-dev libc-dev gcc && \
-        pip --no-cache-dir install docker-compose awscli aws-sam-cli && \
+ENV DOCKER_COMPOSE_VERSION=1.23.2
+
+RUN apk --no-cache add bash curl libffi-dev groff less python py-pip jq python-dev libc-dev gcc make libressl-dev && \
+        python -m ensurepip && \
+        pip --no-cache-dir install awscli aws-sam-cli docker-compose~=${DOCKER_COMPOSE_VERSION} && \
         rm -rf /var/cache/apk/*
+
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
 FROM docker:stable
 LABEL maintainer "Nithiwat Kampanya"
 
-ENV DOCKER_COMPOSE_VERSION=1.23.2
-
-RUN apk --no-cache add bash curl libffi-dev groff less python py-pip jq python-dev libc-dev gcc make libressl-dev && \
+RUN apk --no-cache add bash curl zip groff less python jq python-dev libc-dev gcc make libffi-dev && \
         python -m ensurepip && \
-        pip --no-cache-dir install awscli aws-sam-cli docker-compose~=${DOCKER_COMPOSE_VERSION} && \
+        pip --no-cache-dir install awscli aws-sam-cli docker-compose && \
         rm -rf /var/cache/apk/*
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Wanted to add bash and curl to the image to improve our CICD processes

The image wouldn't build as docker-compose 1.24 (latest version) now requires `make` and `libffi-dev`

`python -m ensurepip` simply helps get a more current version of pip than alpine distributes