### PR TITLE
fixes current build error to actually successfully build again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker:latest
+FROM docker:stable
 LABEL maintainer "Nithiwat Kampanya"
 
-RUN apk --no-cache add zip groff less python py-pip jq python-dev libc-dev gcc && \
+RUN apk --no-cache add zip groff less python py-pip jq python-dev libc-dev gcc libffi-dev openssl-dev make && \
         pip --no-cache-dir install docker-compose awscli aws-sam-cli && \
         rm -rf /var/cache/apk/*


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22773848/61731079-b48e8380-ad48-11e9-8b34-947e26fea25e.png)

The existing code, as is, generates the above error if you try to docker build against it.

This PR will add in the missing dependencies, and switches docker to docker:stable (the 'latest' non-experimental/rc/test build)