### PR TITLE
fix default pool red herring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,6 @@ LABEL maintainer "Nithiwat Kampanya"
 RUN apk --no-cache add zip groff less python py-pip jq python-dev libc-dev gcc libffi-dev openssl-dev make && \
         pip --no-cache-dir install docker-compose awscli aws-sam-cli && \
         rm -rf /var/cache/apk/*
+
+# Fix "WARNING: Connection pool is full, discarding connection: " red-herring
+RUN sed -i 's/DEFAULT_POOLSIZE = 10/DEFAULT_POOLSIZE = 300/' /usr/lib/python2.7/site-packages/requests/adapters.py


### PR DESCRIPTION
This will stop the error messages:

```
WARNING: Connection pool is full, discarding connection: 
```

This is not actually a problem, but every time there's a failed pipeline, this message catches peoples eyes. This has never actually been the cause of a problem.